### PR TITLE
Remove unused  dependency from AccessToken service

### DIFF
--- a/app/scripts/services/access-token.js
+++ b/app/scripts/services/access-token.js
@@ -2,8 +2,8 @@
 
 var accessTokenService = angular.module('oauth.accessToken', ['ngStorage']);
 
-accessTokenService.factory('AccessToken', ['$rootScope', '$location', '$http', '$sessionStorage',
-  function($rootScope, $location, $http, $sessionStorage) {
+accessTokenService.factory('AccessToken', ['$rootScope', '$location', '$sessionStorage',
+  function($rootScope, $location, $sessionStorage) {
 
   var service = {};
   var token   = null;

--- a/dist/oauth-ng.js
+++ b/dist/oauth-ng.js
@@ -1,4 +1,4 @@
-/* oauth-ng - v0.2.2 - 2014-07-10 */
+/* oauth-ng - v0.2.2 - 2014-07-18 */
 
 'use strict';
 
@@ -21,8 +21,8 @@ angular.module('oauth').config(['$locationProvider','$httpProvider',
 
 var accessTokenService = angular.module('oauth.accessToken', ['ngStorage']);
 
-accessTokenService.factory('AccessToken', ['$rootScope', '$location', '$http', '$sessionStorage',
-  function($rootScope, $location, $http, $sessionStorage) {
+accessTokenService.factory('AccessToken', ['$rootScope', '$location', '$sessionStorage',
+  function($rootScope, $location, $sessionStorage) {
 
   var service = {};
   var token   = null;


### PR DESCRIPTION
Using the `AccessToken` service inside of a http interceptor (e.g. https://github.com/witoldsz/angular-http-auth) results in a circular dependency. Since the `$http` provider is not used at all in the `AccessToken` service I propose to remove it to solve the circular dependency.
