### PR TITLE
Broadcast the profile when available using the message 'ouath:profile'

### DIFF
--- a/dist/oauth-ng.js
+++ b/dist/oauth-ng.js
@@ -347,6 +347,7 @@ directives.directive('oauth', function(AccessToken, Endpoint, Profile, $location
       if (token && token.access_token && scope.profileUri) {
         Profile.find(scope.profileUri).success(function(response) {
           scope.profile = response
+          $rootScope.$broadcast('oauth:profile', response);
         })
       }
     };


### PR DESCRIPTION
After receiving `oauth:authorized` or `oauth:login` messages, using the `get()` method on the `Profile` directive is not available until some time later when the user profile request has completed.

One option is to have `Profile.get()` return a promise, however this may be a breaking change for other users of `oauth-ng`.

As an alternative, this pull request broadcasts an `oauth:profile` message with the profile attached as message data.
