### PR TITLE
fix(protractor): Replace $timeout with $interval

### DIFF
--- a/app/scripts/services/access-token.js
+++ b/app/scripts/services/access-token.js
@@ -2,7 +2,7 @@
 
 var accessTokenService = angular.module('oauth.accessToken', ['ngStorage']);
 
-accessTokenService.factory('AccessToken', function($rootScope, $location, $sessionStorage, $timeout){
+accessTokenService.factory('AccessToken', function($rootScope, $location, $sessionStorage, $interval){
 
     var service = {
             token: null
@@ -144,9 +144,9 @@ accessTokenService.factory('AccessToken', function($rootScope, $location, $sessi
     var setExpiresAtEvent = function(){
         var time = (new Date(service.token.expires_at))-(new Date());
         if(time){
-            $timeout(function(){
+            $interval(function(){
                 $rootScope.$broadcast('oauth:expired', service.token)
-            }, time)
+            }, time, 1)
         }
     };
 

--- a/dist/oauth-ng.js
+++ b/dist/oauth-ng.js
@@ -20,7 +20,7 @@ angular.module('oauth').config(['$locationProvider','$httpProvider',
 
 var accessTokenService = angular.module('oauth.accessToken', ['ngStorage']);
 
-accessTokenService.factory('AccessToken', function($rootScope, $location, $sessionStorage, $timeout){
+accessTokenService.factory('AccessToken', function($rootScope, $location, $sessionStorage, $interval){
 
     var service = {
             token: null
@@ -162,9 +162,9 @@ accessTokenService.factory('AccessToken', function($rootScope, $location, $sessi
     var setExpiresAtEvent = function(){
         var time = (new Date(service.token.expires_at))-(new Date());
         if(time){
-            $timeout(function(){
+            $interval(function(){
                 $rootScope.$broadcast('oauth:expired', service.token)
-            }, time)
+            }, time, 1)
         }
     };
 


### PR DESCRIPTION
Submitting this one more time.  I was a bad citizen and made my changes to the "dist/oauth-ng" file.  Changes are now made to the correct source files.

Protractor E2E tests timeout and fail while waiting on all $timeouts()
to complete. Basically, protractor is waiting for the token to expire.
Thankfully, protractor does not wait until $interval() functions are
complete, since they are typically used for polling events. Using an
$interval with a count of 1 is essentially the same thing as calling
$timeout and the protractor tests pass.
