### PR TITLE
Act on token expiration by deleting token and updating directive UI.

### DIFF
--- a/app/scripts/directives/oauth.js
+++ b/app/scripts/directives/oauth.js
@@ -79,6 +79,11 @@ directives.directive('oauth', function(AccessToken, Endpoint, Profile, $location
       loggedOut();
     };
 
+    scope.$on('oauth:expired', function() {
+      AccessToken.destroy(scope);
+      scope.show = 'logged-out';
+    });
+
     // user is authorized
     var authorized = function() {
       $rootScope.$broadcast('oauth:authorized', AccessToken.get());


### PR DESCRIPTION
As it is, oauth-ng will continue to assume the saved token works even if it has already expired. Namely, the text in the directive will still ask for a Logout.

Now, I've seen in #17 that there are some plans for adding auto-renewal capaibilities. This sounds really cool. However, in the meanwhile, I suggest we put the directive back into a 'logged-off' status upon token expiration.

I've tested this in my web app and it appears to be working ok. After token expiration it now updates the directive to show 'Sign in' instead of 'Sign off' and we can request a renewal directly by clicking on it once instead of twice (without this, we'd need one click to make the directive logout and another to make it login again).

I'm not sure if we should actively destroy the token or not though. It works well in my workflow but perhaps the old token is needed for some renewal processes? 
