### PR TITLE
Support for loading keys from .well-known/openid-configuration

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -47,6 +47,7 @@
     <!-- build:js({.tmp,app}) oauth-ng.js -->
     <script src="scripts/app.js"></script>
     <script src="scripts/services/id-token.js"></script>
+    <script src="scripts/services/oidc-config.js"></script>
     <script src="scripts/services/access-token.js"></script>
     <script src="scripts/services/endpoint.js"></script>
     <script src="scripts/services/profile.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -4,6 +4,7 @@
 angular.module('oauth', [
   'oauth.directive',      // login directive
   'oauth.idToken',        // id token service (only for OpenID Connect)
+  'oauth.oidcConfig',     // for loading OIDC configuration from .well-known/openid-configuration endpoint
   'oauth.accessToken',    // access token service
   'oauth.endpoint',       // oauth endpoint service
   'oauth.profile',        // profile model

--- a/app/scripts/services/id-token.js
+++ b/app/scripts/services/id-token.js
@@ -142,9 +142,20 @@ idTokenService.factory('IdToken', ['Storage', function(Storage) {
        TODO: Support for "jku" (JWK Set URL), "x5u" (X.509 URL), "x5c" (X.509 Certificate Chain) parameter to get key
        per http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-26#page-9
        */
-    } else { //Use configured public key
-      var jwk = getJsonObject(this.pubKey);
-      matchedPubKey = jwk ? jwk : this.pubKey; //JWK or PEM
+    } else {
+      //Try to load the key from .well-known configuration
+      var oidcConfig = Storage.get('oidcConfig');
+      if (angular.isDefined(oidcConfig) && oidcConfig.jwks && oidcConfig.jwks.keys) {
+        oidcConfig.jwks.keys.forEach(function(key) {
+          if (key.kid === header.kid) {
+            matchedPubKey = key;
+          }
+        });
+      } else {
+        //Use configured public key
+        var jwk = getJsonObject(this.pubKey);
+        matchedPubKey = jwk ? jwk : this.pubKey; //JWK or PEM
+      }
     }
 
     if(!matchedPubKey) {

--- a/app/scripts/services/oidc-config.js
+++ b/app/scripts/services/oidc-config.js
@@ -1,0 +1,62 @@
+(function() {
+  'use strict';
+
+  angular.module('oauth.oidcConfig', [])
+    .factory('OidcConfig', ['Storage', '$http', '$q', OidcConfig]);
+
+  function OidcConfig(Storage, $http, $q) {
+    var cache = null;
+    return {
+      load: load
+    };
+
+    function load(scope) {
+      if (scope.issuer && scope.wellKnown && scope.wellKnown !== "false") {
+        var promise = loadConfig(scope.issuer);
+        if (scope.wellKnown === "sync") {
+          return promise;
+        }
+      }
+      return $q.when(1);
+    }
+
+    function loadConfig(iss) {
+      if (cache === null) {
+        cache = Storage.get('oidcConfig');
+      }
+      if (angular.isDefined(cache)) {
+        return $q.when(cache);
+      } else {
+        return loadOpenidConfiguration(iss)
+                .then(saveCache)
+                .then(loadJwks)
+                .then(saveCache);
+      }
+    }
+
+    function saveCache(o) {
+      Storage.set('oidcConfig', cache);
+      return o;
+    }
+
+    function joinPath(x,y) {
+      return x + (x.charAt(x.length - 1) === '/' ? '' : '/') + y;
+    }
+
+    function loadOpenidConfiguration(iss) {
+      return $http.get(joinPath(iss, ".well-known/openid-configuration")).then(function(res) {
+        return cache = res.data;
+      });
+    }
+
+    function loadJwks(oidcConf) {
+      if (oidcConf.jwks_uri) {
+        return $http.get(oidcConf.jwks_uri).then(function(res) {
+          return oidcConf.jwks = res.data;
+        });
+      } else {
+        return $q.reject("No jwks_uri found.");
+      }
+    }
+  }
+})();

--- a/dist/oauth-ng.js
+++ b/dist/oauth-ng.js
@@ -1,4 +1,4 @@
-/* oauth-ng - v0.4.9 - 2016-03-13 */
+/* oauth-ng - v0.4.9 - 2016-03-24 */
 
 'use strict';
 
@@ -6,6 +6,7 @@
 angular.module('oauth', [
   'oauth.directive',      // login directive
   'oauth.idToken',        // id token service (only for OpenID Connect)
+  'oauth.oidcConfig',     // for loading OIDC configuration from .well-known/openid-configuration endpoint
   'oauth.accessToken',    // access token service
   'oauth.endpoint',       // oauth endpoint service
   'oauth.profile',        // profile model
@@ -162,9 +163,20 @@ idTokenService.factory('IdToken', ['Storage', function(Storage) {
        TODO: Support for "jku" (JWK Set URL), "x5u" (X.509 URL), "x5c" (X.509 Certificate Chain) parameter to get key
        per http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-26#page-9
        */
-    } else { //Use configured public key
-      var jwk = getJsonObject(this.pubKey);
-      matchedPubKey = jwk ? jwk : this.pubKey; //JWK or PEM
+    } else {
+      //Try to load the key from .well-known configuration
+      var oidcConfig = Storage.get('oidcConfig');
+      if (angular.isDefined(oidcConfig) && oidcConfig.jwks && oidcConfig.jwks.keys) {
+        oidcConfig.jwks.keys.forEach(function(key) {
+          if (key.kid === header.kid) {
+            matchedPubKey = key;
+          }
+        });
+      } else {
+        //Use configured public key
+        var jwk = getJsonObject(this.pubKey);
+        matchedPubKey = jwk ? jwk : this.pubKey; //JWK or PEM
+      }
     }
 
     if(!matchedPubKey) {
@@ -278,6 +290,65 @@ idTokenService.factory('IdToken', ['Storage', function(Storage) {
   return service;
 
 }]);
+
+(function() {
+  'use strict';
+
+  angular.module('oauth.oidcConfig', [])
+    .factory('OidcConfig', ['Storage', '$http', '$q', OidcConfig]);
+
+  function OidcConfig(Storage, $http, $q) {
+    var cache = null;
+    return {
+      load: load
+    };
+
+    function load(scope) {
+      if (scope.issuer && scope.wellKnown && scope.wellKnown !== "false") {
+        var promise = loadConfig(scope.issuer);
+        if (scope.wellKnown === "sync") {
+          return promise;
+        }
+      }
+      return $q.resolve(1);
+    }
+
+    function loadConfig(iss) {
+      if (cache === null) {
+        cache = Storage.get('oidcConfig');
+      }
+      if (angular.isDefined(cache)) {
+        return $q.resolve(cache);
+      } else {
+        return loadOpenidConfiguration(iss)
+                .then(saveCache)
+                .then(loadJwks)
+                .then(saveCache);
+      }
+    }
+
+    function saveCache(o) {
+      Storage.set('oidcConfig', cache);
+      return o;
+    }
+
+    function loadOpenidConfiguration(iss) {
+      return $http.get(iss + ".well-known/openid-configuration").then(function(res) {
+        return cache = res.data;
+      });
+    }
+
+    function loadJwks(oidcConf) {
+      if (oidcConf.jwks_uri) {
+        return $http.get(oidcConf.jwks_uri).then(function(res) {
+          return oidcConf.jwks = res.data;
+        });
+      } else {
+        return $q.reject("No jwks_uri found.");
+      }
+    }
+  }
+})();
 
 'use strict';
 
@@ -746,13 +817,14 @@ directives.directive('oauth', [
   'Endpoint',
   'Profile',
   'Storage',
+  'OidcConfig',
   '$location',
   '$rootScope',
   '$compile',
   '$http',
   '$templateCache',
   '$timeout',
-  function(IdToken, AccessToken, Endpoint, Profile, Storage, $location, $rootScope, $compile, $http, $templateCache, $timeout) {
+  function(IdToken, AccessToken, Endpoint, Profile, Storage, OidcConfig, $location, $rootScope, $compile, $http, $templateCache, $timeout) {
 
     var definition = {
       restrict: 'AE',
@@ -774,6 +846,7 @@ directives.directive('oauth', [
         issuer: '@',         // (optional for OpenID Connect) issuer of the id_token, should match the 'iss' claim in id_token payload
         subject: '@',        // (optional for OpenID Connect) subject of the id_token, should match the 'sub' claim in id_token payload
         pubKey: '@',          // (optional for OpenID Connect) the public key(RSA public key or X509 certificate in PEM format) to verify the signature
+        wellKnown: '@',       // (optional for OpenID Connect) whether to load public key according to .well-known/openid-configuration endpoint
         logoutPath: '@',    // (optional) A url to go to at logout
         sessionPath: '@'    // (optional) A url to use to check the validity of the current token.
       }
@@ -791,11 +864,14 @@ directives.directive('oauth', [
         Storage.use(scope.storage);// set storage
         compile();                 // compiles the desired layout
         Endpoint.set(scope);       // sets the oauth authorization url
-        IdToken.set(scope);
-        AccessToken.set(scope);    // sets the access token object (if existing, from fragment or session)
-        initProfile(scope);        // gets the profile resource (if existing the access token)
-        initView();                // sets the view (logged in or out)
-        checkValidity();           // ensure the validity of the current token
+        OidcConfig.load(scope)     // loads OIDC configuration from .well-known/openid-configuration if necessary
+          .then(function() {
+            IdToken.set(scope);
+            AccessToken.set(scope);    // sets the access token object (if existing, from fragment or session)
+            initProfile(scope);        // gets the profile resource (if existing the access token)
+            initView();                // sets the view (logged in or out)
+            checkValidity();           // ensure the validity of the current token
+          });
       };
 
       var initAttributes = function() {

--- a/test/spec/services/oidc-config.js
+++ b/test/spec/services/oidc-config.js
@@ -1,0 +1,87 @@
+describe('IdToken', function() {
+
+  var IdToken, OidcConfig;
+
+  var publicKeyModulus, publicKeyExponent;
+  var validIdToken;
+  var $httpBackend;
+
+  beforeEach(module('oauth'));
+
+  beforeEach(inject(function ($injector) {
+    IdToken = $injector.get('IdToken');
+  }));
+
+  beforeEach(function () {
+    /**
+     * http://kjur.github.io/jsjws/tool_jwt.html generated sample id_token, signed by default private key
+     * The public key modulus and exponent are as below. This is the same public key as in id-token.js test.
+     */
+    publicKeyModulus = '33TqqLR3eeUmDtHS89qF3p4MP7Wfqt2Zjj3lZjLjjCGDvwr9cJNlN' +
+                       'DiuKboODgUiT4ZdPWbOiMAfDcDzlOxA04DDnEFGAf-kDQiNSe2Ztq' +
+                       'C7bnIc8-KSG_qOGQIVaay4Ucr6ovDkykO5Hxn7OU7sJp9TP9H0JH8' +
+                       'zMQA6YzijYH9LsupTerrY3U6zyihVEDXXOv08vBHk50BMFJbE9iwF' +
+                       'wnxCsU5-UZUZYw87Uu0n4LPFS9BT8tUIvAfnRXIEWCha3KbFWmdZQ' +
+                       'ZlyrFw0buUEf0YN3_Q0auBkdbDR_ES2PbgKTJdkjc_rEeM0TxvOUf' +
+                       '7HuUNOhrtAVEN1D5uuxE1WSw';
+    publicKeyExponent = 'AQAB';
+  });
+
+  beforeEach(inject(function ($injector) {
+    OidcConfig = $injector.get('OidcConfig');
+    $httpBackend = $injector.get('$httpBackend');
+    $httpBackend.when('GET', 'oidc/.well-known/openid-configuration')
+                .respond({jwks_uri: "oidc/jwks_uri"});
+    $httpBackend.when('GET', 'oidc/jwks_uri')
+                .respond({
+                  keys: [{
+                      kty: 'RSA',
+                      n: publicKeyModulus,
+                      e: publicKeyExponent,
+                      kid: 'rsa1'
+                    }
+                  ]
+                });
+  }));
+
+
+  describe('validate an id_token when pubkey is loaded from .well-known configuration', function() {
+    beforeEach(function () {
+      /*
+        Valid token with RS256, expires at 20251231235959Z UTC
+        https://jwt.io has a debugger that can help view the id_token's header and payload
+
+        e.g. The header of following token is { "alg": "RS256", "typ": "JWT", "kid": "rsa1" }
+             The body of the following token is:
+             {
+               "iss": "oidc",
+               "sub": "oauth-ng-client",
+               "nbf": 1449267385,
+               "exp": 1767225599,
+               "iat": 1449267385,
+               "jti": "id123456",
+               "typ": "https://example.com/register"
+             }
+       */
+      validIdToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InJzYTEifQ' +
+          '.eyJpc3MiOiJvaWRjIiwic3ViIjoib2F1dGgtbmctY2xpZW50IiwibmJmIjoxNDQ5MjY3Mzg1LCJleHAiOjE3NjcyMjU1OTksImlhdCI6MTQ0OTI2NzM4NSwianRpIjoiaWQxMjM0NTYiLCJ0eXAiOiJodHRwczovL2V4YW1wbGUuY29tL3JlZ2lzdGVyIn0' +
+          '.J39k8LK_lu7xYvW_eU-MAI3jtgQEdkpJOlx4ZX_WZ3TUyY-9GG0xLUusteDcy3UGIVxangwonaZ7311WKKz9OwjU1ePivMLXayiP2bL6srIUu8PvOOIcf8oPt8HGv-TLb1zPmYPx3XniekKUEnFAxMGedobcX0wg9tZnnkM11T4qQPcTjDhKB9bNlih9yRHR-6OkKZN4Q_by7EJAPJti22L0dTCW81A_9J5OMXoe0k6fScGfc0Wspsc7CpBN9ZAmTUdHGe8IP5L4leM0pOud6M0gzcIhixR1OMm6qj7ZyvJxgZ48h7Fln3CHyz3LGoHBTQWWDf3ufTzl3sGvippc1w';
+
+      var scope = {
+        issuer: 'oidc',
+        clientId: 'oauth-ng-client',
+        wellKnown: 'sync'
+      };
+
+      OidcConfig.load(scope).then(function(){
+        IdToken.set(scope);
+      })
+      $httpBackend.flush();
+    });
+
+    it('with success', function () {
+      expect(IdToken.validateIdToken(validIdToken)).toEqual(true);
+    });
+
+  });
+});


### PR DESCRIPTION
Currently in oauth-ng the public keys for verifying idTokens should either be provided with tokens or separately configured.

Openid Connect also describes a possibility to load them dynamically using AP's published configuration (located at <issuer>/.well-known/openid-configuration):
https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig

This PR implements the support for this, which could be controlled via well-known configuration parameter. Its values correspond to:
1) falsy -> don't load keys in this way,
2) sync -> load keys synchronously before initializing oauth-ng services,
3) truthy -> load keys asynchonously.
