### PR TITLE
Add logout capability.  Add session validity checking feature.

### DIFF
--- a/app/scripts/directives/oauth.js
+++ b/app/scripts/directives/oauth.js
@@ -91,7 +91,7 @@ directives.directive('oauth', [
         var token = AccessToken.get();
 
         if (!token) {
-          return loggedOut();
+          return scope.logout();
         }  // without access token it's logged out
         if (AccessToken.expired()) {
           return expired();
@@ -109,8 +109,6 @@ directives.directive('oauth', [
       };
 
       scope.logout = function () {
-        AccessToken.destroy(scope);
-        $rootScope.$broadcast('oauth:logout');
         Endpoint.logout();
         $rootScope.$broadcast('oauth:loggedOut');
         scope.show = 'logged-out';
@@ -138,9 +136,8 @@ directives.directive('oauth', [
       var checkValidity = function() {
         Endpoint.checkValidity().then(function() {
           $rootScope.$broadcast('oauth:valid');
-        }).catch(function(){
-          $rootScope.$broadcast('oauth:invalid');
-          scope.logout();
+        }).catch(function(message){
+          $rootScope.$broadcast('oauth:invalid', message);
         });
       };
 

--- a/app/scripts/services/endpoint.js
+++ b/app/scripts/services/endpoint.js
@@ -2,9 +2,29 @@
 
 var endpointClient = angular.module('oauth.endpoint', []);
 
-endpointClient.factory('Endpoint', function() {
+endpointClient.factory('Endpoint', function($rootScope, AccessToken, $q, $http) {
 
   var service = {};
+
+  var buildOauthUrl = function (path, params) {
+    var oAuthScope = (params.scope) ? params.scope : '',
+      state = (params.state) ? encodeURIComponent(params.state) : '',
+      authPathHasQuery = (params.authorizePath.indexOf('?') == -1) ? false : true,
+      appendChar = (authPathHasQuery) ? '&' : '?',    //if authorizePath has ? already append OAuth2 params
+      nonceParam = (params.nonce) ? '&nonce=' + params.nonce : '';
+
+    return params.site +
+      path +
+      appendChar + 'response_type=token&' +
+      'client_id=' + encodeURIComponent(params.clientId) + '&' +
+      'redirect_uri=' + encodeURIComponent(params.redirectUri) + '&' +
+      'scope=' + oAuthScope + '&' +
+      'state=' + state + nonceParam;
+  };
+
+  var extendValidity = function (tokenInfo) {
+    AccessToken.updateExpiry(tokenInfo.expires);
+  };
 
   /*
    * Defines the authorization URL
@@ -19,35 +39,67 @@ endpointClient.factory('Endpoint', function() {
    * Returns the authorization URL
    */
 
-  service.get = function( overrides ) {
+  service.get = function(overrides) {
     var params = angular.extend( {}, service.config, overrides);
-    var oAuthScope = (params.scope) ? encodeURIComponent(params.scope) : '',
-        state = (params.state) ? encodeURIComponent(params.state) : '',
-        authPathHasQuery = (params.authorizePath.indexOf('?') === -1) ? false : true,
-        appendChar = (authPathHasQuery) ? '&' : '?',    //if authorizePath has ? already append OAuth2 params
-        responseType = (params.responseType) ? encodeURIComponent(params.responseType) : '';
-
-    var url = params.site +
-          params.authorizePath +
-          appendChar + 'response_type=' + responseType + '&' +
-          'client_id=' + encodeURIComponent(params.clientId) + '&' +
-          'redirect_uri=' + encodeURIComponent(params.redirectUri) + '&' +
-          'scope=' + oAuthScope + '&' +
-          'state=' + state;
-
-    if( params.nonce ) {
-      url = url + '&nonce=' + params.nonce;
-    }
-    return url;
+    return buildOauthUrl(params.authorizePath, params);
   };
 
   /*
    * Redirects the app to the authorization URL
    */
 
-  service.redirect = function( overrides ) {
-    var targetLocation = this.get( overrides );
+  service.redirect = function(overrides) {
+    var targetLocation = this.get(overrides);
+    $rootScope.$broadcast('oauth:logging-in');
     window.location.replace(targetLocation);
+  };
+
+  /*
+   * Alias for 'redirect'
+   */
+  service.login = function() {
+    service.redirect();
+  };
+
+  /*
+   * Check the validity of the token if a session path is available
+   */
+  service.checkValidity = function() {
+    var params = service.config;
+    if( params.sessionPath ) {
+      var token = AccessToken.get().access_token;
+      if( !token ) {
+        return $q.reject("No token configured");
+      }
+      var path = params.site + params.sessionPath + "?token=" + token;
+      return $http.get(path).then( function(httpResponse) {
+        var tokenInfo = httpResponse.data;
+        if(tokenInfo.valid) {
+          extendValidity(tokenInfo);
+          return true;
+        } else {
+          return $q.reject("Server replied: token is invalid.");
+        }
+      });
+    } else {
+      return $q.reject("You must give a :session-path param in order to validate the token.")
+    }
+  };
+
+  /*
+   * Destroys the session, sends the user to the logout url if set.
+   * First broadcasts 'logging-out' and then 'logout' when finished.
+   */
+
+  service.logout = function() {
+    var params = service.config;
+    AccessToken.destroy();
+    $rootScope.$broadcast('oauth:logging-out');
+    if( params.logoutPath ) {
+      window.location.replace(buildOauthUrl(params.logOutPath, params));
+    } else {
+      $rootScope.$broadcast('oauth:logout');
+    }
   };
 
   return service;

--- a/app/scripts/services/endpoint.js
+++ b/app/scripts/services/endpoint.js
@@ -7,15 +7,16 @@ endpointClient.factory('Endpoint', function($rootScope, AccessToken, $q, $http) 
   var service = {};
 
   var buildOauthUrl = function (path, params) {
-    var oAuthScope = (params.scope) ? params.scope : '',
+    var oAuthScope = (params.scope) ? encodeURIComponent(params.scope) : '',
       state = (params.state) ? encodeURIComponent(params.state) : '',
       authPathHasQuery = (params.authorizePath.indexOf('?') == -1) ? false : true,
       appendChar = (authPathHasQuery) ? '&' : '?',    //if authorizePath has ? already append OAuth2 params
-      nonceParam = (params.nonce) ? '&nonce=' + params.nonce : '';
+      nonceParam = (params.nonce) ? '&nonce=' + params.nonce : '',
+      responseType = encodeURIComponent(params.responseType);
 
     return params.site +
       path +
-      appendChar + 'response_type=token&' +
+      appendChar + 'response_type=' + responseType + '&' +
       'client_id=' + encodeURIComponent(params.clientId) + '&' +
       'redirect_uri=' + encodeURIComponent(params.redirectUri) + '&' +
       'scope=' + oAuthScope + '&' +
@@ -67,11 +68,11 @@ endpointClient.factory('Endpoint', function($rootScope, AccessToken, $q, $http) 
   service.checkValidity = function() {
     var params = service.config;
     if( params.sessionPath ) {
-      var token = AccessToken.get().access_token;
+      var token = AccessToken.get();
       if( !token ) {
         return $q.reject("No token configured");
       }
-      var path = params.site + params.sessionPath + "?token=" + token;
+      var path = params.site + params.sessionPath + "?token=" + token.access_token;
       return $http.get(path).then( function(httpResponse) {
         var tokenInfo = httpResponse.data;
         if(tokenInfo.valid) {
@@ -97,9 +98,8 @@ endpointClient.factory('Endpoint', function($rootScope, AccessToken, $q, $http) 
     $rootScope.$broadcast('oauth:logging-out');
     if( params.logoutPath ) {
       window.location.replace(buildOauthUrl(params.logOutPath, params));
-    } else {
-      $rootScope.$broadcast('oauth:logout');
     }
+    $rootScope.$broadcast('oauth:logout');
   };
 
   return service;

--- a/bower.json
+++ b/bower.json
@@ -25,5 +25,8 @@
     "bootstrap-sass": "~3.0.2",
     "jquery": "~1.9.1",
     "angular-mocks": "~1.3.12"
+  },
+  "resolutions": {
+    "angular": "1.3.20"
   }
 }

--- a/dist/oauth-ng.js
+++ b/dist/oauth-ng.js
@@ -1,4 +1,4 @@
-/* oauth-ng - v0.4.5 - 2016-01-06 */
+/* oauth-ng - v0.4.6 - 2016-02-09 */
 
 'use strict';
 
@@ -295,6 +295,7 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
     //Additional OpenID Connect key per http://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthResponse
     'id_token'
   ];
+  var expiresAtEvent = null;
 
   /**
    * Returns the access token.
@@ -352,6 +353,14 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
       setToken(this.token);
       $rootScope.$broadcast('oauth:login', service.token);
     }
+  };
+
+   /**
+    * updates the expiration of the token
+    */
+  service.updateExpiry = function(newExpiresIn){
+    this.token.expires_in = newExpiresIn;
+    setExpiresAt();
   };
 
   /* * * * * * * * * *
@@ -442,11 +451,19 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
     if (typeof(service.token.expires_at) === 'undefined' || service.token.expires_at === null) {
       return;
     }
+    cancelExpiresAtEvent();
     var time = (new Date(service.token.expires_at))-(new Date());
     if(time && time > 0 && time <= 2147483647){
-      $interval(function(){
+      expiresAtEvent = $interval(function(){
         $rootScope.$broadcast('oauth:expired', service.token);
       }, time, 1);
+    }
+  };
+
+  var cancelExpiresAtEvent = function() {
+    if(expiresAtEvent) {
+      $timeout.cancel(expiresAtEvent);
+      expiresAtEvent = undefined;
     }
   };
 
@@ -471,9 +488,29 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
 
 var endpointClient = angular.module('oauth.endpoint', []);
 
-endpointClient.factory('Endpoint', function() {
+endpointClient.factory('Endpoint', function($rootScope, AccessToken, $q, $http) {
 
   var service = {};
+
+  var buildOauthUrl = function (path, params) {
+    var oAuthScope = (params.scope) ? params.scope : '',
+      state = (params.state) ? encodeURIComponent(params.state) : '',
+      authPathHasQuery = (params.authorizePath.indexOf('?') == -1) ? false : true,
+      appendChar = (authPathHasQuery) ? '&' : '?',    //if authorizePath has ? already append OAuth2 params
+      nonceParam = (params.nonce) ? '&nonce=' + params.nonce : '';
+
+    return params.site +
+      path +
+      appendChar + 'response_type=token&' +
+      'client_id=' + encodeURIComponent(params.clientId) + '&' +
+      'redirect_uri=' + encodeURIComponent(params.redirectUri) + '&' +
+      'scope=' + oAuthScope + '&' +
+      'state=' + state + nonceParam;
+  };
+
+  var extendValidity = function (tokenInfo) {
+    AccessToken.updateExpiry(tokenInfo.expires);
+  };
 
   /*
    * Defines the authorization URL
@@ -488,35 +525,67 @@ endpointClient.factory('Endpoint', function() {
    * Returns the authorization URL
    */
 
-  service.get = function( overrides ) {
+  service.get = function(overrides) {
     var params = angular.extend( {}, service.config, overrides);
-    var oAuthScope = (params.scope) ? encodeURIComponent(params.scope) : '',
-        state = (params.state) ? encodeURIComponent(params.state) : '',
-        authPathHasQuery = (params.authorizePath.indexOf('?') === -1) ? false : true,
-        appendChar = (authPathHasQuery) ? '&' : '?',    //if authorizePath has ? already append OAuth2 params
-        responseType = (params.responseType) ? encodeURIComponent(params.responseType) : '';
-
-    var url = params.site +
-          params.authorizePath +
-          appendChar + 'response_type=' + responseType + '&' +
-          'client_id=' + encodeURIComponent(params.clientId) + '&' +
-          'redirect_uri=' + encodeURIComponent(params.redirectUri) + '&' +
-          'scope=' + oAuthScope + '&' +
-          'state=' + state;
-
-    if( params.nonce ) {
-      url = url + '&nonce=' + params.nonce;
-    }
-    return url;
+    return buildOauthUrl(params.authorizePath, params);
   };
 
   /*
    * Redirects the app to the authorization URL
    */
 
-  service.redirect = function( overrides ) {
-    var targetLocation = this.get( overrides );
+  service.redirect = function(overrides) {
+    var targetLocation = this.get(overrides);
+    $rootScope.$broadcast('oauth:logging-in');
     window.location.replace(targetLocation);
+  };
+
+  /*
+   * Alias for 'redirect'
+   */
+  service.login = function() {
+    service.redirect();
+  };
+
+  /*
+   * Check the validity of the token if a session path is available
+   */
+  service.checkValidity = function() {
+    var params = service.config;
+    if( params.sessionPath ) {
+      var token = AccessToken.get().access_token;
+      if( !token ) {
+        return $q.reject("No token configured");
+      }
+      var path = params.site + params.sessionPath + "?token=" + token;
+      return $http.get(path).then( function(httpResponse) {
+        var tokenInfo = httpResponse.data;
+        if(tokenInfo.valid) {
+          extendValidity(tokenInfo);
+          return true;
+        } else {
+          return $q.reject("Server replied: token is invalid.");
+        }
+      });
+    } else {
+      return $q.reject("You must give a :session-path param in order to validate the token.")
+    }
+  };
+
+  /*
+   * Destroys the session, sends the user to the logout url if set.
+   * First broadcasts 'logging-out' and then 'logout' when finished.
+   */
+
+  service.logout = function() {
+    var params = service.config;
+    AccessToken.destroy();
+    $rootScope.$broadcast('oauth:logging-out');
+    if( params.logoutPath ) {
+      window.location.replace(buildOauthUrl(params.logOutPath, params));
+    } else {
+      $rootScope.$broadcast('oauth:logout');
+    }
   };
 
   return service;
@@ -703,7 +772,9 @@ directives.directive('oauth', [
                              // OpenID Connect extras, more details in id-token.js:
         issuer: '@',         // (optional for OpenID Connect) issuer of the id_token, should match the 'iss' claim in id_token payload
         subject: '@',        // (optional for OpenID Connect) subject of the id_token, should match the 'sub' claim in id_token payload
-        pubKey: '@'          // (optional for OpenID Connect) the public key(RSA public key or X509 certificate in PEM format) to verify the signature
+        pubKey: '@',          // (optional for OpenID Connect) the public key(RSA public key or X509 certificate in PEM format) to verify the signature
+        logoutPath: '@',    // (optional) A url to go to at logout
+        sessionPath: '@'    // (optional) A url to use to check the validity of the current token.
       }
     };
 
@@ -723,6 +794,7 @@ directives.directive('oauth', [
         AccessToken.set(scope);    // sets the access token object (if existing, from fragment or session)
         initProfile(scope);        // gets the profile resource (if existing the access token)
         initView();                // sets the view (logged in or out)
+        checkValidity();           // ensure the validity of the current token
       };
 
       var initAttributes = function() {
@@ -753,34 +825,36 @@ directives.directive('oauth', [
         }
       };
 
-      var initView = function() {
+      var initView = function () {
         var token = AccessToken.get();
 
         if (!token) {
-          return loggedOut(); // without access token it's logged out
-        }
+          return loggedOut();
+        }  // without access token it's logged out
+        if (AccessToken.expired()) {
+          return expired();
+        }  // with a token, but it's expired
         if (token.access_token) {
-          return authorized(); // if there is the access token we are done
-        }
+          return authorized();
+        }  // if there is the access token we are done
         if (token.error) {
-          return denied(); // if the request has been denied we fire the denied event
-        }
+          return denied();
+        }  // if the request has been denied we fire the denied event
       };
 
-      scope.login = function() {
+      scope.login = function () {
         Endpoint.redirect();
       };
 
-      scope.logout = function() {
+      scope.logout = function () {
         AccessToken.destroy(scope);
         $rootScope.$broadcast('oauth:logout');
-        loggedOut();
+        Endpoint.logout();
+        $rootScope.$broadcast('oauth:loggedOut');
+        scope.show = 'logged-out';
       };
 
-      scope.$on('oauth:expired', function() {
-        AccessToken.destroy(scope);
-        scope.show = 'logged-out';
-      });
+      scope.$on('oauth:expired',expired);
 
       // user is authorized
       var authorized = function() {
@@ -788,16 +862,24 @@ directives.directive('oauth', [
         scope.show = 'logged-in';
       };
 
-      // set the oauth directive to the logged-out status
-      var loggedOut = function() {
-        $rootScope.$broadcast('oauth:loggedOut');
-        scope.show = 'logged-out';
+      var expired = function() {
+        $rootScope.$broadcast('oauth:expired');
+        scope.logout();
       };
 
       // set the oauth directive to the denied status
       var denied = function() {
         scope.show = 'denied';
         $rootScope.$broadcast('oauth:denied');
+      };
+
+      var checkValidity = function() {
+        Endpoint.checkValidity().then(function() {
+          $rootScope.$broadcast('oauth:valid');
+        }).catch(function(){
+          $rootScope.$broadcast('oauth:invalid');
+          scope.logout();
+        });
       };
 
       // Updates the template at runtime

--- a/test/spec/directives/oauth.js
+++ b/test/spec/directives/oauth.js
@@ -2,12 +2,16 @@
 
 describe('oauth', function() {
 
-  var $rootScope, $location, Storage, $httpBackend, $compile, AccessToken, Endpoint, element, scope, result, callback;
+  var $rootScope, $location, Storage, $httpBackend, $compile, AccessToken, Endpoint, element, scope, result, callback,
+      validCallback, invalidCallback;
 
   var fragment = 'access_token=token&token_type=bearer&expires_in=7200&state=/path';
   var denied = 'error=access_denied&error_description=error';
   var headers = { 'Accept': 'application/json, text/plain, */*', 'Authorization': 'Bearer token' };
   var profile = { id: '1', full_name: 'Alice Wonderland', email: 'alice@example.com' };
+  var session = { valid: true , expires: ((new Date()).getTime() + 356*24*60*60) };
+  var invalidSession = { valid: false };
+  var invalidProfile = { valid: false };
 
   beforeEach(module('oauth'));
   beforeEach(module('templates'));
@@ -27,7 +31,10 @@ describe('oauth', function() {
           'client="client-id"' +
           'redirect="http://example.com/redirect"' +
           'scope="scope"' +
-          'profile-uri="http://example.com/me">Sign In</oauth>' +
+          'profile-uri="http://example.com/me"' +
+          'session-path="/session"' +
+          '>Sign In' +
+          '</oauth>' +
       '</span>'
     );
   });
@@ -42,120 +49,149 @@ describe('oauth', function() {
 
     beforeEach(function() {
       callback = jasmine.createSpy('callback');
+      validCallback = jasmine.createSpy('validCallback');
+      $rootScope.$on('oauth:valid', validCallback);
     });
 
     beforeEach(function() {
       $location.hash(fragment);
     });
 
-    beforeEach(function() {
-      $httpBackend.whenGET('http://example.com/me', headers).respond(profile);
-    });
-
-    beforeEach(function() {
-      $rootScope.$on('oauth:authorized', callback);
-    });
-
-    beforeEach(function() {
-      $rootScope.$on('oauth:login', callback);
-    });
-
-    beforeEach(function() {
-      compile($rootScope, $compile);
-    });
-
-    it('shows the link "Logout #{profile.email}"', function() {
-      $rootScope.$apply();
-      $httpBackend.flush();
-      result = element.find('.logged-in').text();
-      expect(result).toBe('Logout alice@example.com');
-    });
-
-    it('removes the fragment', function() {
-      expect($location.hash()).toBe('');
-    });
-
-    it('shows the logout link', function() {
-      expect(element.find('.logged-out').attr('class')).toMatch('ng-hide');
-      expect(element.find('.logged-in').attr('class')).not.toMatch('ng-hide');
-    });
-
-    it('fires the oauth:login and oauth:authorized event', function() {
-      AccessToken.get();
-      expect(callback.calls.count()).toBe(2);
-    });
-
-
-    describe('when refreshes the page', function() {
-
-      beforeEach(function() {
-        callback = jasmine.createSpy('callback');
+    describe('invalid session', function () {
+      beforeEach(function () {
+        invalidCallback = jasmine.createSpy('invalidCallback');
+        $httpBackend.whenGET('http://example.com/me', headers).respond(invalidProfile);
+        $httpBackend.whenGET('http://example.com/session?token=token').respond(invalidSession);
+        $rootScope.$on('oauth:invalid', invalidCallback);
       });
 
-      beforeEach(function() {
-        $rootScope.$on('oauth:authorized', callback);
-      });
-
-      beforeEach(function() {
-        $location.path('/');
-      });
-
-      beforeEach(function() {
+      beforeEach(function () {
         compile($rootScope, $compile);
       });
 
-      it('keeps being logged in', function() {
+      it('hits the session and is invalid', function () {
+        $httpBackend.flush();
+        expect(invalidCallback.calls.count()).toBe(1);
+      });
+    });
+
+    describe('valid session', function () {
+
+      beforeEach(function () {
+        $httpBackend.whenGET('http://example.com/me', headers).respond(profile);
+        $httpBackend.whenGET('http://example.com/session?token=token').respond(session);
+      });
+
+      beforeEach(function () {
+        $rootScope.$on('oauth:authorized', callback);
+      });
+
+      beforeEach(function () {
+        $rootScope.$on('oauth:login', callback);
+      });
+
+      beforeEach(function () {
+        compile($rootScope, $compile);
+      });
+
+      it('shows the link "Logout #{profile.email}"', function () {
         $rootScope.$apply();
         $httpBackend.flush();
         result = element.find('.logged-in').text();
         expect(result).toBe('Logout alice@example.com');
       });
 
-      it('shows the logout link', function() {
+      it('removes the fragment', function () {
+        expect($location.hash()).toBe('');
+      });
+
+      it('shows the logout link', function () {
         expect(element.find('.logged-out').attr('class')).toMatch('ng-hide');
         expect(element.find('.logged-in').attr('class')).not.toMatch('ng-hide');
       });
 
-      it('fires the oauth:authorized event', function() {
-        var event = jasmine.any(Object);
-        var token = AccessToken.get();
-        expect(callback).toHaveBeenCalledWith(event, token);
-      });
-
-      it('does not fire the oauth:login event', function() {
+      it('fires the oauth:login and oauth:authorized event', function () {
         AccessToken.get();
-        expect(callback.calls.count()).toBe(1);
-      });
-    });
-
-
-    describe('when logs out', function() {
-
-      beforeEach(function() {
-        callback = jasmine.createSpy('callback');
-      });
-
-      beforeEach(function() {
-        $rootScope.$on('oauth:logout', callback);
-      });
-
-      beforeEach(function() {
-        $rootScope.$on('oauth:loggedOut', callback);
-      });
-
-      beforeEach(function() {
-        element.find('.logged-in').click();
-      });
-
-      it('shows the login link', function() {
-        expect(element.find('.logged-out').attr('class')).not.toMatch('ng-hide');
-        expect(element.find('.logged-in').attr('class')).toMatch('ng-hide');
-      });
-
-      it('fires the oauth:logout and oauth:loggedOut event', function() {
-        var event = jasmine.any(Object);
-        expect(callback).toHaveBeenCalledWith(event);
         expect(callback.calls.count()).toBe(2);
+      });
+
+      it('hits the session and is valid', function () {
+        $httpBackend.flush();
+        expect(validCallback.calls.count()).toBe(1);
+      });
+
+
+      describe('when refreshes the page', function () {
+
+        beforeEach(function () {
+          callback = jasmine.createSpy('callback');
+        });
+
+        beforeEach(function () {
+          $rootScope.$on('oauth:authorized', callback);
+        });
+
+        beforeEach(function () {
+          $location.path('/');
+        });
+
+        beforeEach(function () {
+          compile($rootScope, $compile);
+        });
+
+        it('keeps being logged in', function () {
+          $rootScope.$apply();
+          $httpBackend.flush();
+          result = element.find('.logged-in').text();
+          expect(result).toBe('Logout alice@example.com');
+        });
+
+        it('shows the logout link', function () {
+          expect(element.find('.logged-out').attr('class')).toMatch('ng-hide');
+          expect(element.find('.logged-in').attr('class')).not.toMatch('ng-hide');
+        });
+
+        it('fires the oauth:authorized event', function () {
+          var event = jasmine.any(Object);
+          var token = AccessToken.get();
+          expect(callback).toHaveBeenCalledWith(event, token);
+        });
+
+        it('does not fire the oauth:login event', function () {
+          AccessToken.get();
+          expect(callback.calls.count()).toBe(1);
+        });
+      });
+
+
+      describe('when logs out', function () {
+
+        beforeEach(function () {
+          callback = jasmine.createSpy('callback');
+        });
+
+        beforeEach(function () {
+          $rootScope.$on('oauth:logout', callback);
+        });
+
+        beforeEach(function () {
+          $rootScope.$on('oauth:loggedOut', callback);
+        });
+
+        beforeEach(function () {
+          element.find('.logged-in').click();
+        });
+
+        it('shows the login link', function () {
+          expect(element.find('.logged-out').attr('class')).not.toMatch('ng-hide');
+          expect(element.find('.logged-in').attr('class')).toMatch('ng-hide');
+        });
+
+        it('fires the oauth:logout and oauth:loggedOut event', function () {
+          var event = jasmine.any(Object);
+          expect(callback).toHaveBeenCalledWith(event);
+          expect(callback.calls.count()).toBe(2);
+        });
       });
     });
   });
@@ -165,6 +201,9 @@ describe('oauth', function() {
 
     beforeEach(function() {
       callback = jasmine.createSpy('callback');
+      invalidCallback = jasmine.createSpy('invalidCallback');
+      $httpBackend.whenGET('http://example.com/session?token=token').respond(invalidSession);
+      $rootScope.$on('oauth:invalid', invalidCallback);
     });
 
     beforeEach(function() {
@@ -206,6 +245,10 @@ describe('oauth', function() {
     it('does not fire the oauth:logout event', function() {
       expect(callback.calls.count()).toBe(1);
     });
+
+    it('fires the oauth:invalid event', function () {
+      expect(invalidCallback.calls.count()).toBe(1);
+    });
   });
 
 
@@ -213,6 +256,7 @@ describe('oauth', function() {
 
     beforeEach(function() {
       callback = jasmine.createSpy('callback');
+      $httpBackend.whenGET('http://example.com/session?token=undefined').respond(invalidSession);
     });
 
     beforeEach(function() {

--- a/test/spec/services/access-token.js
+++ b/test/spec/services/access-token.js
@@ -11,6 +11,7 @@ describe('AccessToken', function() {
       '&id_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ&expires_in=3600';
   var denied   = 'error=access_denied&error_description=error';
   var expires_at = '2014-08-17T17:38:37.584Z';
+  var newExpiresIn = 9600;
   var token    = { access_token: 'token', token_type: 'bearer', expires_in: 7200, state: '/path', expires_at: expires_at };
 
   beforeEach(module('oauth'));
@@ -294,6 +295,23 @@ describe('AccessToken', function() {
       it('returns true', function() {
         expect(result).toBe(true);
       });
+    });
+  });
+
+  describe('#updateExpiry', function () {
+    beforeEach(function () {
+      $location.hash('');
+      Storage.set('token', token);
+      AccessToken.set();
+    });
+
+
+    it('updates the expiry to a new time', function () {
+      AccessToken.updateExpiry(newExpiresIn);
+      expect(AccessToken.expired()).toBeFalsy();
+      var newExpiresAt = new Date();
+      newExpiresAt.setSeconds(newExpiresAt.getSeconds() + newExpiresIn - 60);
+      expect(AccessToken.get().expires_at).toEqual(newExpiresAt);
     });
   });
 


### PR DESCRIPTION
**Overview:**
This will add two new params to the directive configuration..
> logout-path
> session-path

**Session Path**
When set, compilation of the directive will fire a request to the oauth server to check validity of the session.  Users who use this configuration may listen for the ```oauth:valid``` check to inform them if the user's session is still valid.  This is very helpful when re-opening an older session to ensure that the token the user has in session storage is still valid OR that they haven't purged their session(s) from some other system.  If the session is invalid, ```oauth:invalid``` will be fired.  You may use that callback to logout the user or do any other house keeping as necessary for your application.

**Logout Path**
The logout path adds a logout to redirect to when the user clicks to "logout".  It is used by calling ```Endpoint.logout()``` if you wish to log out the user manually, and this will trigger a browser redirect.