### PR TITLE
Add explicit annotation to Endpoint factory

### DIFF
--- a/app/scripts/services/endpoint.js
+++ b/app/scripts/services/endpoint.js
@@ -2,7 +2,7 @@
 
 var endpointClient = angular.module('oauth.endpoint', []);
 
-endpointClient.factory('Endpoint', function($rootScope, AccessToken, $q, $http) {
+endpointClient.factory('Endpoint', ['$rootScope', 'AccessToken', '$q', '$http', function($rootScope, AccessToken, $q, $http) {
 
   var service = {};
 
@@ -103,4 +103,4 @@ endpointClient.factory('Endpoint', function($rootScope, AccessToken, $q, $http) 
   };
 
   return service;
-});
+}]);


### PR DESCRIPTION
The Endpoint factory is using implicit annotation, which causes problems when minifying the code. 