### PR TITLE
Fixes error thrown by cancelExpiresAtEvent

### DIFF
--- a/app/scripts/services/access-token.js
+++ b/app/scripts/services/access-token.js
@@ -2,7 +2,7 @@
 
 var accessTokenService = angular.module('oauth.accessToken', []);
 
-accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location', '$interval', 'IdToken', function(Storage, $rootScope, $location, $interval, IdToken){
+accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location', '$interval', 'IdToken', '$timeout', function(Storage, $rootScope, $location, $interval, IdToken, $timeout){
 
   var service = {
     token: null

--- a/dist/oauth-ng.js
+++ b/dist/oauth-ng.js
@@ -1,4 +1,4 @@
-/* oauth-ng - v0.4.8 - 2016-02-12 */
+/* oauth-ng - v0.4.8 - 2016-03-08 */
 
 'use strict';
 
@@ -283,7 +283,7 @@ idTokenService.factory('IdToken', ['Storage', function(Storage) {
 
 var accessTokenService = angular.module('oauth.accessToken', []);
 
-accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location', '$interval', 'IdToken', function(Storage, $rootScope, $location, $interval, IdToken){
+accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location', '$interval', 'IdToken', '$timeout', function(Storage, $rootScope, $location, $interval, IdToken, $timeout){
 
   var service = {
     token: null


### PR DESCRIPTION
cancelExpiresAtEvent function uses $timeout but it is not injected into the factory.

This causes a blocking javascript error to be thrown when AccessToken.setTokenFromString is called.