### PR TITLE
Fix issue where the package assumes a global bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node": ">=0.8.0"
   },
   "scripts": {
-    "postinstall": "bower install",
+    "postinstall": "./node_modules/bower/bin/bower install",
     "clean": "rm -rf node_modules dist app/bower_components",
     "test": "grunt test && grunt build"
   },


### PR DESCRIPTION
This becomes an issue when oauth-ng is required by other projects: npm install fails if bower isn't installed globally.