### PR TITLE
Switching token == nil -> Login instead of logout (should make SSO situations work more seamlessly)

### DIFF
--- a/app/scripts/directives/oauth.js
+++ b/app/scripts/directives/oauth.js
@@ -97,8 +97,8 @@ directives.directive('oauth', [
         var token = AccessToken.get();
 
         if (!token) {
-          return scope.logout();
-        }  // without access token it's logged out
+          return scope.login();
+        }  // without access token it's logged out, so we attempt to log in
         if (AccessToken.expired()) {
           return expired();
         }  // with a token, but it's expired

--- a/dist/oauth-ng.js
+++ b/dist/oauth-ng.js
@@ -1,4 +1,4 @@
-/* oauth-ng - v0.4.10 - 2016-04-25 */
+/* oauth-ng - v0.4.10 - 2016-05-25 */
 
 'use strict';
 
@@ -918,8 +918,8 @@ directives.directive('oauth', [
         var token = AccessToken.get();
 
         if (!token) {
-          return scope.logout();
-        }  // without access token it's logged out
+          return scope.login();
+        }  // without access token it's logged out, so we attempt to log in
         if (AccessToken.expired()) {
           return expired();
         }  // with a token, but it's expired


### PR DESCRIPTION
This basically switches the behaviour when there is no token found, to attempt to hit the auth service to get it as opposed to forcefully logging out. This had the inadvertent effect of preventing a seamless SSO handoff between apps if you don't have a session, you'd be FORCED to log in again even if you just logged in.
