### PR TITLE
Fix NPM postinstall script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "node": ">=0.8.0"
   },
   "scripts": {
-    "postinstall": "bower install",
     "clean": "rm -rf node_modules dist app/bower_components",
     "test": "grunt test && grunt build"
   },


### PR DESCRIPTION
Bower install is quite unnecessary and creates problems for npm.