### PR TITLE
Remove deprecated functions

### DIFF
--- a/app/scripts/directives/oauth.js
+++ b/app/scripts/directives/oauth.js
@@ -77,8 +77,8 @@ directives.directive('oauth', [
       };
 
       var compile = function() {
-        $http.get(scope.template, { cache: $templateCache }).success(function(html) {
-          element.html(html);
+        $http.get(scope.template, { cache: $templateCache }).then(function(html) {
+          element.html(html.data);
           $compile(element.contents())(scope);
         });
       };
@@ -87,8 +87,8 @@ directives.directive('oauth', [
         var token = AccessToken.get();
 
         if (token && token.access_token && scope.profileUri) {
-          Profile.find(scope.profileUri).success(function(response) {
-            scope.profile = response;
+          Profile.find(scope.profileUri).then(function(response) {
+            scope.profile = response.data;
           });
         }
       };

--- a/app/scripts/services/profile.js
+++ b/app/scripts/services/profile.js
@@ -8,8 +8,8 @@ profileClient.factory('Profile', ['$http', 'AccessToken', '$rootScope', function
 
   service.find = function(uri) {
     var promise = $http.get(uri, { headers: headers() });
-    promise.success(function(response) {
-        profile = response;
+    promise.then(function(response) {
+        profile = response.data;
         $rootScope.$broadcast('oauth:profile', profile);
       });
     return promise;


### PR DESCRIPTION
$http's deprecated callback methods - success() and error() - have been removed from angular 1.6.
Using then() allow the user of oauth-ng to use angular 1.6